### PR TITLE
Improve manifest handling

### DIFF
--- a/release/firmware/update/fetch.go
+++ b/release/firmware/update/fetch.go
@@ -110,11 +110,18 @@ func NewFetcher(ctx context.Context, opts FetcherOpts) (*Fetcher, error) {
 		binFetcher:  opts.BinaryFetcher,
 		scanFrom:    0,
 	}
-	f.manifestVerifiers = map[string][]note.Verifier{
-		ftlog.ComponentApplet:   {opts.AppletVerifier},
-		ftlog.ComponentBoot:     {opts.BootVerifier},
-		ftlog.ComponentOS:       opts.OSVerifiers[:],
-		ftlog.ComponentRecovery: {opts.RecoveryVerifier},
+	f.manifestVerifiers = make(map[string][]note.Verifier)
+	if v := opts.AppletVerifier; v != nil {
+		f.manifestVerifiers[ftlog.ComponentApplet] = []note.Verifier{v}
+	}
+	if v := opts.BootVerifier; v != nil {
+		f.manifestVerifiers[ftlog.ComponentBoot] = []note.Verifier{v}
+	}
+	if v := opts.OSVerifiers; len(v) > 0 {
+		f.manifestVerifiers[ftlog.ComponentOS] = v[:]
+	}
+	if v := opts.RecoveryVerifier; v != nil {
+		f.manifestVerifiers[ftlog.ComponentRecovery] = []note.Verifier{v}
 	}
 	// IFF we were provided the previously used checkpoint, we'll override the
 	// log index at which we'll start scanning.

--- a/release/firmware/update/update.go
+++ b/release/firmware/update/update.go
@@ -96,6 +96,9 @@ func (u Updater) Update(ctx context.Context) error {
 	if err != nil {
 		return fmt.Errorf("failed to get latest versions: %v", err)
 	}
+
+	klog.Infof("Installed (os: %v applet: %v)", u.osVer, u.appVer)
+	klog.Infof("Updates (os: %v applet: %v)", osVer, appVer)
 	if u.osVer.LessThan(osVer) {
 		klog.Infof("Upgrading OS from %q to %q", u.osVer, osVer)
 		bundle, err := u.remote.GetOS(ctx)
@@ -110,7 +113,7 @@ func (u Updater) Update(ctx context.Context) error {
 		}
 	}
 	if u.appVer.LessThan(appVer) {
-		klog.Infof("Upgrading applet from %q to %q", u.osVer, osVer)
+		klog.Infof("Upgrading applet from %q to %q", u.appVer, appVer)
 		bundle, err := u.remote.GetApplet(ctx)
 		if err != nil {
 			return fmt.Errorf("failed to fetch applet firmware: %v", err)


### PR DESCRIPTION
This PR makes manifest handling a bit more resilient:
 - For the update process, the fetcher will now correctly operate when only a subset of manifest verification keys are provided (e.g. just the OS and Applet keys)
 - The `BundleVerifier.Verify` func now returns the opened manifest which was used to verify the bundle, rather than forcing the caller to re-perform this operation.