### PR TITLE
Firmware binary path is CAS-like

### DIFF
--- a/release/firmware/update/fetch.go
+++ b/release/firmware/update/fetch.go
@@ -19,7 +19,6 @@ import (
 	"encoding/json"
 	"errors"
 	"fmt"
-	"net/url"
 	"sync"
 
 	"github.com/coreos/go-semver/semver"
@@ -66,25 +65,10 @@ type FetcherOpts struct {
 
 // BinaryPath returns the relative path within a bucket for the binary referenced by the manifest.
 func BinaryPath(fr ftlog.FirmwareRelease) (string, error) {
-	dir := ""
-	file := ""
-	switch fr.Component {
-	case ftlog.ComponentApplet:
-		dir = "trusted-applet"
-		file = "trusted_applet.elf"
-	case ftlog.ComponentBoot:
-		dir = "boot"
-		file = "armored-witness-boot.imx"
-	case ftlog.ComponentOS:
-		dir = "trusted-os"
-		file = "trusted_os.elf"
-	case ftlog.ComponentRecovery:
-		dir = "recovery"
-		file = "armory-ums.imx"
-	default:
-		return "", fmt.Errorf("unrecognised component %q", fr.Component)
+	if len(fr.FirmwareDigestSha256) == 0 {
+		return "", errors.New("firmware digest unset")
 	}
-	return url.JoinPath(dir, fr.GitTagName.String(), file)
+	return fmt.Sprintf("%064x", fr.FirmwareDigestSha256), nil
 }
 
 // NewFetcher returns an implementation of a Remote that uses the given log client to


### PR DESCRIPTION
This PR redefines the path to a firmware to be a lower-case hex string of the binary's SHA256 hash.

Having the binaries in a CAS (as opposed to in a directory structure containing release versions, type, etc.) has a few benefits in our scenario:
- it provides a forcing function for binaries to always be accessed via the FT log (since the binary in the manifest is referenced only by its hash). This serves as a good reference example and helps folks do the right thing.
- it avoids any risk of binaries being accidentally overwritten due to accidental moving of git tags between commits, or by external inputs (e.g. env vars) which alter the binary not being captured in the path.
