### PR TITLE
Manifest can contain the build environment variables

### DIFF
--- a/release/firmware/ftlog/example_firmware_release.json
+++ b/release/firmware/ftlog/example_firmware_release.json
@@ -4,6 +4,10 @@
     "git_commit_fingerprint": "aac1e176cfac1a1e079b5f624b83fda54b5d0f76",
     "firmware_digest_sha256": "8l4TaroPsSq+zwG+XMPZw+EdpUoXH0IT4cKM2RmFyNE=",
     "tamago_version": "1.20.6",
+    "build_envs": [
+        "DEBUG=1",
+        "CHECK=no"
+    ],
     "hab": {
         "target": "ci",
         "signature_digest_sha256": "8l4TaroPsSq+zwG+XMPZw+EdpUoXH0IT4cKM2RmFyNE="

--- a/release/firmware/ftlog/log_entries.go
+++ b/release/firmware/ftlog/log_entries.go
@@ -64,6 +64,10 @@ type FirmwareRelease struct {
 	// [Tamago]: https://github.com/usbarmory/tamago
 	TamagoVersion semver.Version `json:"tamago_version"`
 
+	// BuildEnvs contains all environment variables set for this build. Each value in the string
+	// array will be a single key/value assignment, such as "DEBUG=1".
+	BuildEnvs []string `json:"build_envs"`
+
 	// HAB holds a signature and related data for firmware which must be authenticated
 	// by the device's mask ROM at boot.
 	// Currently, this is only meaningful for Bootloader and Recovery firmware images.

--- a/release/firmware/ftlog/log_entries_test.go
+++ b/release/firmware/ftlog/log_entries_test.go
@@ -19,6 +19,7 @@ import (
 	"encoding/base64"
 	"encoding/json"
 	"os"
+	"reflect"
 	"testing"
 
 	"github.com/coreos/go-semver/semver"
@@ -54,6 +55,9 @@ func TestParseFirmwareRelease(t *testing.T) {
 		t.Errorf("Got %x, want %x", got, want)
 	}
 	if got, want := r.TamagoVersion, *semver.New("1.20.6"); got != want {
+		t.Errorf("Got %q, want %q", got, want)
+	}
+	if got, want := r.BuildEnvs, []string{"DEBUG=1", "CHECK=no"}; !reflect.DeepEqual(got, want) {
 		t.Errorf("Got %q, want %q", got, want)
 	}
 	if got, want := r.HAB.Target, "ci"; got != want {


### PR DESCRIPTION
There are a number of these that are set differently in the different environments that will produce different outputs. Having all of these explicitly committed to in the manifest makes it crystal clear what features were enabled/disabled, which is critical for verifiers.
