### PR TITLE
Don't serialise empty sub structs in manifest

### DIFF
--- a/release/firmware/ftlog/log_entries.go
+++ b/release/firmware/ftlog/log_entries.go
@@ -71,7 +71,7 @@ type FirmwareRelease struct {
 	// HAB holds a signature and related data for firmware which must be authenticated
 	// by the device's mask ROM at boot.
 	// Currently, this is only meaningful for Bootloader and Recovery firmware images.
-	HAB HAB `json:"hab"`
+	HAB *HAB `json:"hab,omitempty"`
 }
 
 // HAB holds information relating to SecureBoot.

--- a/release/firmware/update/fetch_test.go
+++ b/release/firmware/update/fetch_test.go
@@ -137,22 +137,38 @@ func TestFetcher(t *testing.T) {
 				{
 					{Component: ftlog.ComponentOS, GitTagName: *semver.New("1.0.1")},
 					{Component: ftlog.ComponentApplet, GitTagName: *semver.New("1.1.1")},
-					{HAB: ftlog.HAB{Target: "orange"}, Component: ftlog.ComponentBoot, GitTagName: *semver.New("1.3.1")},
-					{HAB: ftlog.HAB{Target: "orange"}, Component: ftlog.ComponentRecovery, GitTagName: *semver.New("1.1.1")},
+					{HAB: &ftlog.HAB{Target: "orange"}, Component: ftlog.ComponentBoot, GitTagName: *semver.New("1.3.1")},
+					{HAB: &ftlog.HAB{Target: "orange"}, Component: ftlog.ComponentRecovery, GitTagName: *semver.New("1.1.1")},
 				},
 				{
-					{HAB: ftlog.HAB{Target: "orange"}, Component: ftlog.ComponentBoot, GitTagName: *semver.New("1.4.1")},
-					{HAB: ftlog.HAB{Target: "banana"}, Component: ftlog.ComponentRecovery, GitTagName: *semver.New("1.8.1")}, // this should be ignored
+					{HAB: &ftlog.HAB{Target: "orange"}, Component: ftlog.ComponentBoot, GitTagName: *semver.New("1.4.1")},
+					{HAB: &ftlog.HAB{Target: "banana"}, Component: ftlog.ComponentRecovery, GitTagName: *semver.New("1.8.1")}, // this should be ignored
 				},
 			},
 			want: [][]ftlog.FirmwareRelease{
 				{
-					{HAB: ftlog.HAB{Target: "orange"}, Component: ftlog.ComponentBoot, GitTagName: *semver.New("1.3.1")},
-					{HAB: ftlog.HAB{Target: "orange"}, Component: ftlog.ComponentRecovery, GitTagName: *semver.New("1.1.1")},
+					{HAB: &ftlog.HAB{Target: "orange"}, Component: ftlog.ComponentBoot, GitTagName: *semver.New("1.3.1")},
+					{HAB: &ftlog.HAB{Target: "orange"}, Component: ftlog.ComponentRecovery, GitTagName: *semver.New("1.1.1")},
 				},
 				{
-					{HAB: ftlog.HAB{Target: "orange"}, Component: ftlog.ComponentBoot, GitTagName: *semver.New("1.4.1")},
-					{HAB: ftlog.HAB{Target: "orange"}, Component: ftlog.ComponentRecovery, GitTagName: *semver.New("1.1.1")},
+					{HAB: &ftlog.HAB{Target: "orange"}, Component: ftlog.ComponentBoot, GitTagName: *semver.New("1.4.1")},
+					{HAB: &ftlog.HAB{Target: "orange"}, Component: ftlog.ComponentRecovery, GitTagName: *semver.New("1.1.1")},
+				},
+			},
+		}, {
+			desc:      "Missing HAB section",
+			habTarget: "orange", // only match HAB signed firmware targetting "orange" devices
+			releases: [][]ftlog.FirmwareRelease{
+				{
+					{Component: ftlog.ComponentOS, GitTagName: *semver.New("1.0.1")},
+					{Component: ftlog.ComponentApplet, GitTagName: *semver.New("1.1.1")},
+					{HAB: &ftlog.HAB{Target: "orange"}, Component: ftlog.ComponentBoot, GitTagName: *semver.New("1.1.1")},
+					{HAB: nil, Component: ftlog.ComponentBoot, GitTagName: *semver.New("1.3.1")},
+				},
+			},
+			want: [][]ftlog.FirmwareRelease{
+				{
+					{HAB: &ftlog.HAB{Target: "orange"}, Component: ftlog.ComponentBoot, GitTagName: *semver.New("1.1.1")},
 				},
 			},
 		}, {


### PR DESCRIPTION
This PR makes empty sub-structs (e.g. `HAB` or `BuildEnvs`) in the manifest be omitted during serialisation.