### PR TITLE
Clearer logging in self-update

### DIFF
--- a/release/firmware/update/update.go
+++ b/release/firmware/update/update.go
@@ -97,8 +97,6 @@ func (u Updater) Update(ctx context.Context) error {
 		return fmt.Errorf("failed to get latest versions: %v", err)
 	}
 
-	klog.Infof("Installed (os: %v applet: %v)", u.osVer, u.appVer)
-	klog.Infof("Updates (os: %v applet: %v)", osVer, appVer)
 	if u.osVer.LessThan(osVer) {
 		klog.Infof("Upgrading OS from %q to %q", u.osVer, osVer)
 		bundle, err := u.remote.GetOS(ctx)
@@ -125,5 +123,6 @@ func (u Updater) Update(ctx context.Context) error {
 			return fmt.Errorf("failed to install applet firmware: %v", err)
 		}
 	}
+	klog.Infof("Self-update: no updates applied (os: %v applet: %v)", u.osVer, u.appVer)
 	return nil
 }


### PR DESCRIPTION
The old logging appeared as:

```
I0307 15:41:31.709551       3 update.go:100] Installed (os: 0.3.1709825047-incompatible applet: 0.3.1709823315-incompatible)
I0307 15:41:31.721181       3 update.go:101] Updates (os: 0.3.1709825047-incompatible applet: 0.3.1709823315-incompatible)
```

This takes up two lines on a regular schedule, and looks like it is performing an operation.
This logging has now been moved to only when no updates are applied and takes a single line.

When an update is being applied, we still get an entry that says `Upgrading OS/applet from X to Y`.
