### PR TITLE
Fix broken scorecard workflow action

### DIFF
--- a/.github/workflows/scorecard.yml
+++ b/.github/workflows/scorecard.yml
@@ -27,7 +27,7 @@ jobs:
       # Needed to publish results and get a badge (see publish_results below).
       id-token: write
       # Uncomment the permissions below if installing in a private repository.
-      # contents: read
+      contents: read
       # actions: read
 
     steps:


### PR DESCRIPTION
The scorecard workflow check failed because the `contents: read` permission was revoked by the organization setting.

https://github.com/transparency-dev/armored-witness-common/actions/runs/13810753509/job/38631984886

```
GITHUB_TOKEN Permissions
  Metadata: read
  SecurityEvents: write
...
...
...
2025/03/12 12:04:14 scorecard had an error: repo unreachable: GET https://api.github.com/repos/transparency-dev/armored-witness-common: 401 Bad credentials []
```