### PR TITLE
Bump golangci-lint to 2.1.5

### DIFF
--- a/.github/workflows/golangci-lint.yml
+++ b/.github/workflows/golangci-lint.yml
@@ -16,8 +16,8 @@ jobs:
         with:
           go-version-file: go.mod
       - name: golangci-lint
-        uses: golangci/golangci-lint-action@55c2c1448f86e01eaae002a5a3a9624417608d84 # v6.5.2
+        uses: golangci/golangci-lint-action@1481404843c368bc19ca9406f87d6e0fc97bdcfd # v7.0.0
         with:
           # Optional: version of golangci-lint to use in form of v1.2 or v1.2.3 or `latest` to use the latest version
-          version: v1.64.7
+          version: v2.1.5
           args: --timeout 5m

--- a/release/firmware/update/fetch_test.go
+++ b/release/firmware/update/fetch_test.go
@@ -27,7 +27,6 @@ import (
 	"github.com/transparency-dev/serverless-log/testonly"
 	"golang.org/x/mod/sumdb/note"
 
-	"github.com/transparency-dev/formats/log"
 	fmtlog "github.com/transparency-dev/formats/log"
 	slog "github.com/transparency-dev/serverless-log/pkg/log"
 )
@@ -307,7 +306,7 @@ func addReleasesToLog(ctx context.Context, t *testing.T, ms *testonly.MemStorage
 	if err != nil {
 		t.Fatalf("Fetch checkpoint: %v", err)
 	}
-	cp, _, _, err := log.ParseCheckpoint(cpRaw, origin, lv)
+	cp, _, _, err := fmtlog.ParseCheckpoint(cpRaw, origin, lv)
 	if err != nil {
 		t.Fatalf("ParseCheckpoint: %v", err)
 	}


### PR DESCRIPTION
Unblock https://github.com/transparency-dev/armored-witness-common/pull/49.