### PR TITLE
Bump Go version from 1.23 to 1.24

### DIFF
--- a/.github/workflows/go_test.yml
+++ b/.github/workflows/go_test.yml
@@ -6,7 +6,7 @@ jobs:
   test:
     strategy:
       matrix:
-        go-version: [1.23.x]
+        go-version: [ '1.24.x', '1.25.x' ]
         os: [ubuntu-latest, macos-latest]
     runs-on: ${{ matrix.os }}
     steps:

--- a/go.mod
+++ b/go.mod
@@ -1,8 +1,8 @@
 module github.com/transparency-dev/armored-witness-common
 
-go 1.23.0
+go 1.24.0
 
-toolchain go1.23.7
+toolchain go1.24.7
 
 require (
 	github.com/coreos/go-semver v0.3.1


### PR DESCRIPTION
Unblock https://github.com/transparency-dev/armored-witness-common/pull/66.